### PR TITLE
close #4

### DIFF
--- a/viewer/CMakeLists.txt
+++ b/viewer/CMakeLists.txt
@@ -1,3 +1,5 @@
+FIND_PACKAGE(Qt4)
+
 QT4_WRAP_CPP(moc_sources
   GuiController.h
   DetectorWindow.h


### PR DESCRIPTION
On OS X, at least, Cmake complains about QT4_WRAP_CPP. This fixes it. Closes #4
