### PR TITLE
chessboard masking in projector calibration using rotated rectangles.

### DIFF
--- a/scan-markers/ModelAcquisitionWindow.cpp
+++ b/scan-markers/ModelAcquisitionWindow.cpp
@@ -54,7 +54,7 @@ void ModelAcquisitionWindow::on_resetCamera_clicked()
 
 void ModelAcquisitionWindow::on_saveMeshButton_clicked()
 {
-    if (!m_controller.modelAcquisitionController()->currentImage().withDepthDataAndCalibrated())
+    if (!m_controller.modelAcquisitionController()->currentImage().withRawDepthDataAndCalibrated())
     {
         ntk_dbg(1) << "No image already processed.";
         return;


### PR DESCRIPTION
Dear Nicolas,

Commit 3d0a90f fixes a change of function names introduced by nestk commit df57445a, which caused a compilation error.

Commit 4916b4c improves the projector calibration by masking chessboards with rotated rectangles.
The old axis-aligned rectangles did not work if the kinect views the scene from a different angle and the size of the printed board is smaller.
